### PR TITLE
Remove ability to configure hashing rounds for SHA512 and SHA256

### DIFF
--- a/app/Hashing/Sha256Hasher.php
+++ b/app/Hashing/Sha256Hasher.php
@@ -14,13 +14,6 @@ use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 class Sha256Hasher implements HasherContract
 {
     /**
-     * The default cost factor.
-     *
-     * @var int
-     */
-    protected $rounds = 5000;
-
-    /**
      * Create a new hasher instance.
      *
      * @param  array $options
@@ -28,7 +21,7 @@ class Sha256Hasher implements HasherContract
      */
     public function __construct(array $options = [])
     {
-        $this->rounds = $options['rounds'] ?? $this->rounds;
+        //
     }
 
     /**
@@ -39,15 +32,12 @@ class Sha256Hasher implements HasherContract
      */
     public function info($hashedValue)
     {
-        if (!preg_match('/\$5\$(rounds=[0-9]+\$)?[^\$\s]+\$[^\$\s]+$/', $hashedValue)) {
+        if (!preg_match('/\$5\$[^\$\s]+\$[^\$\s]+$/', $hashedValue)) {
             return password_get_info($hashedValue);
         }
 
         $options = [];
         $matches = [];
-        if (preg_match('/rounds=([0-9]+)\$[^\$\s]+\$[^\$\s]+$/', $hashedValue, $matches)) {
-            $options['rounds'] = (int)$matches[1];
-        }
 
         if (preg_match('/\$([^\$\s]+)\$[^\$\s]+$/', $hashedValue, $matches)) {
             $options['salt'] = $matches[1];
@@ -75,7 +65,7 @@ class Sha256Hasher implements HasherContract
             throw new RuntimeException('SHA256 hashing not supported.');
         }
 
-        $hash = crypt($value, '$5$rounds=' . $this->rounds($options) . '$' . $this->salt($options) . '$');
+        $hash = crypt($value, '$5$' . $this->salt($options) . '$');
 
         return $hash;
     }
@@ -106,35 +96,7 @@ class Sha256Hasher implements HasherContract
      */
     public function needsRehash($hashedValue, array $options = [])
     {
-        $info = $this->info($hashedValue);
-        if ($info['algo'] === 'SHA256') {
-            return $info['options']['rounds'] !== $this->rounds($options);
-        }
         return false;
-    }
-
-    /**
-     * Set the default password work factor.
-     *
-     * @param  int $rounds
-     * @return $this
-     */
-    public function setRounds($rounds)
-    {
-        $this->rounds = (int)$rounds;
-
-        return $this;
-    }
-
-    /**
-     * Extract the rounds value from the options array.
-     *
-     * @param  array $options
-     * @return int
-     */
-    protected function rounds(array $options = [])
-    {
-        return $options['rounds'] ?? $this->rounds;
     }
 
     /**

--- a/tests/Unit/Hashing/Sha256HasherTest.php
+++ b/tests/Unit/Hashing/Sha256HasherTest.php
@@ -14,10 +14,9 @@ class Sha256HasherTest extends TestCase
     public function testInfo()
     {
         $options = [
-            'rounds' => 5001,
             'salt'   => bin2hex(random_bytes(8))
         ];
-        $hash = crypt($this->faker->sentence, '$5$rounds=' . $options['rounds'] . '$' . $options['salt'] . '$');
+        $hash = crypt($this->faker->sentence, '$5$' . $options['salt'] . '$');
 
         $hasher = new Sha256Hasher();
         $info = $hasher->info($hash);
@@ -30,37 +29,22 @@ class Sha256HasherTest extends TestCase
     public function testMake()
     {
         $options = [
-            'rounds' => 5001,
             'salt'   => bin2hex(random_bytes(8))
         ];
         $password = $this->faker->sentence;
-        $expectedHash = crypt($password, '$5$rounds=' . $options['rounds'] . '$' . $options['salt'] . '$');
+        $expectedHash = crypt($password, '$5$' . $options['salt'] . '$');
         $hasher = new Sha256Hasher();
         $hash = $hasher->make($password, $options);
-        $this->assertTrue(hash_equals($expectedHash, $hash));
-    }
-
-    public function testMakeWithFixedRounds()
-    {
-        $options = [
-            'rounds' => 5001,
-            'salt'   => bin2hex(random_bytes(8))
-        ];
-        $password = $this->faker->sentence;
-        $expectedHash = crypt($password, '$5$rounds=' . $options['rounds'] . '$' . $options['salt'] . '$');
-        $hasher = new Sha256Hasher(['rounds' => $options['rounds']]);
-        $hash = $hasher->make($password, ['salt' => $options['salt']]);
         $this->assertTrue(hash_equals($expectedHash, $hash));
     }
 
     public function testCheck()
     {
         $options = [
-            'rounds' => 5001,
             'salt'   => bin2hex(random_bytes(8))
         ];
         $password = $this->faker->unique()->sentence;
-        $hash = crypt($password, '$5$rounds=' . $options['rounds'] . '$' . $options['salt'] . '$');
+        $hash = crypt($password, '$5$' . $options['salt'] . '$');
         $hasher = new Sha256Hasher();
         $this->assertTrue($hasher->check($password, $hash));
         $this->assertFalse($hasher->check($this->faker->unique()->sentence, $hash));
@@ -74,14 +58,12 @@ class Sha256HasherTest extends TestCase
 
     public function testNeedsRehash()
     {
-        $oldOptions = ['rounds' => 5000];
-        $options = ['rounds' => 5001];
         $password = $this->faker->unique()->sentence;
-        $hash = crypt($password, '$5$rounds=' . $oldOptions['rounds'] . '$' . bin2hex(random_bytes(8)) . '$');
-        $sha512hash = crypt($password, '$6$rounds=' . $oldOptions['rounds'] . '$' . bin2hex(random_bytes(8)) . '$');
-        $hasher = new Sha256Hasher($options);
-        $this->assertTrue($hasher->needsRehash($hash));
-        $this->assertFalse($hasher->needsRehash($hash, $oldOptions));
+        $hash = crypt($password, '$5$' . bin2hex(random_bytes(8)) . '$');
+        $sha512hash = crypt($password, '$6$' . bin2hex(random_bytes(8)) . '$');
+        $hasher = new Sha256Hasher();
+        $this->assertFalse($hasher->needsRehash($hash));
+        $this->assertFalse($hasher->needsRehash($hash, []));
         $this->assertFalse($hasher->needsRehash($sha512hash));
     }
 }

--- a/tests/Unit/Hashing/Sha512HasherTest.php
+++ b/tests/Unit/Hashing/Sha512HasherTest.php
@@ -13,10 +13,9 @@ class Sha512HasherTest extends TestCase
     public function testInfo()
     {
         $options = [
-            'rounds' => 5001,
             'salt'   => bin2hex(random_bytes(8))
         ];
-        $hash = crypt($this->faker->sentence, '$6$rounds=' . $options['rounds'] . '$' . $options['salt'] . '$');
+        $hash = crypt($this->faker->sentence, '$6$' . $options['salt'] . '$');
 
         $hasher = new Sha512Hasher();
         $info = $hasher->info($hash);
@@ -29,37 +28,22 @@ class Sha512HasherTest extends TestCase
     public function testMake()
     {
         $options = [
-            'rounds' => 5001,
             'salt'   => bin2hex(random_bytes(8))
         ];
         $password = $this->faker->sentence;
-        $expectedHash = crypt($password, '$6$rounds=' . $options['rounds'] . '$' . $options['salt'] . '$');
+        $expectedHash = crypt($password, '$6$' . $options['salt'] . '$');
         $hasher = new Sha512Hasher();
         $hash = $hasher->make($password, $options);
-        $this->assertTrue(hash_equals($expectedHash, $hash));
-    }
-
-    public function testMakeWithFixedRounds()
-    {
-        $options = [
-            'rounds' => 5001,
-            'salt'   => bin2hex(random_bytes(8))
-        ];
-        $password = $this->faker->sentence;
-        $expectedHash = crypt($password, '$6$rounds=' . $options['rounds'] . '$' . $options['salt'] . '$');
-        $hasher = new Sha512Hasher(['rounds' => $options['rounds']]);
-        $hash = $hasher->make($password, ['salt' => $options['salt']]);
         $this->assertTrue(hash_equals($expectedHash, $hash));
     }
 
     public function testCheck()
     {
         $options = [
-            'rounds' => 5001,
             'salt'   => bin2hex(random_bytes(8))
         ];
         $password = $this->faker->unique()->sentence;
-        $hash = crypt($password, '$6$rounds=' . $options['rounds'] . '$' . $options['salt'] . '$');
+        $hash = crypt($password, '$6$' . $options['salt'] . '$');
         $hasher = new Sha512Hasher();
         $this->assertTrue($hasher->check($password, $hash));
         $this->assertFalse($hasher->check($this->faker->unique()->sentence, $hash));
@@ -73,14 +57,12 @@ class Sha512HasherTest extends TestCase
 
     public function testNeedsRehash()
     {
-        $oldOptions = ['rounds' => 5000];
-        $options = ['rounds' => 5001];
         $password = $this->faker->unique()->sentence;
-        $hash = crypt($password, '$6$rounds=' . $oldOptions['rounds'] . '$' . bin2hex(random_bytes(8)) . '$');
-        $sha256hash = crypt($password, '$5$rounds=' . $oldOptions['rounds'] . '$' . bin2hex(random_bytes(8)) . '$');
-        $hasher = new Sha512Hasher($options);
-        $this->assertTrue($hasher->needsRehash($hash));
-        $this->assertFalse($hasher->needsRehash($hash, $oldOptions));
+        $hash = crypt($password, '$6$' . bin2hex(random_bytes(8)) . '$');
+        $sha256hash = crypt($password, '$5$' . bin2hex(random_bytes(8)) . '$');
+        $hasher = new Sha512Hasher();
+        $this->assertFalse($hasher->needsRehash($hash));
+        $this->assertFalse($hasher->needsRehash($hash, []));
         $this->assertFalse($hasher->needsRehash($sha256hash));
     }
 }


### PR DESCRIPTION
This fixes #14 as it removes the ability to configure the rounds for SHA512 and SHA256 hashing of passwords.