### PR TITLE
Call artisan with www-data user to avoid having root permissions

### DIFF
--- a/app/Console/Commands/SizeMeasurementsReport.php
+++ b/app/Console/Commands/SizeMeasurementsReport.php
@@ -5,7 +5,6 @@ namespace App\Console\Commands;
 use App\Domain;
 use App\Mailbox;
 use App\SizeMeasurement;
-use App\Traits\SizeMeasurable;
 use function array_filter;
 use function array_intersect;
 use function array_keys;
@@ -80,7 +79,8 @@ class SizeMeasurementsReport extends Command
         }
 
         if (!$measurable) {
-            throw new InvalidArgumentException('Could not find a mailbox or domain with this home directory.');
+            throw new InvalidArgumentException(sprintf('Could not find a mailbox or domain with the home directory "%s".',
+                $this->argument('directory')));
         }
 
         $size = $this->getSizeInKibibyte();

--- a/mailbox_size_crawler.sh
+++ b/mailbox_size_crawler.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # MUM - Mailserver User Management
 # Mailbox Size Crawler
-# v0.1.0 / Author: Martin Bock
+# v0.1.1 / Author: Martin Bock
 
 if [[ $# != 2 ]]; then
     >&2 echo "Usage: $0 </path/to/dovecot/home/root> </path/to/mum/artisan>"
@@ -22,5 +22,5 @@ fi
 du -d 2 $1 |
 while read size name
 do
-    /usr/bin/php $2 size-measurements:report ${name} ${size}
+    sudo -u www-data /usr/bin/php $2 size-measurements:report ${name} ${size}
 done


### PR DESCRIPTION
Since the script `mailbox_size_crawler.sh` has to be called by a user with high permissions -- either `root` or something like dovecot's mail user, the artisan call previously was also executed using that user. With this pull request, artisan will be called with the user `www-data` instead.