### PR TITLE
Add ability to search for alias address

### DIFF
--- a/app/Http/Filters/MailboxFilter.php
+++ b/app/Http/Filters/MailboxFilter.php
@@ -182,7 +182,7 @@ class MailboxFilter extends QueryFilter
                 });
             if (sizeof($exploded) >= 2) {
                 $query->orWhere(function (Builder $query) use ($exploded) {
-                    $query->where('local_part', 'LIKE', $exploded[0])
+                    $query->where('local_part', '=', $exploded[0])
                         ->whereHas('domain', function (Builder $query) use ($exploded) {
                             $query->where('domain', 'LIKE', $exploded[1] . '%');
                         });


### PR DESCRIPTION
Instead of only being able to search for the `local_part` **or** the `domain` of an alias, you can now also search for the complete email address.